### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -80,14 +80,14 @@ Python statements.
 .. _coverage: http://nedbatchelder.com/code/coverage/
 .. _linecache: https://rubygems.org/gems/linecache
 
-.. |Downloads| image:: https://pypip.in/download/pyficache/badge.svg
+.. |Downloads| image:: https://img.shields.io/pypi/dm/pyficache.svg
 .. |Linux Build Status| image:: https://travis-ci.org/rocky/python-filecache.svg
    :target: https://travis-ci.org/rocky/python-filecache/
 .. |Windows Build status| image:: https://img.shields.io/appveyor/ci/rocky/python-filecache/master.svg?label=windows%20build
    :target: https://ci.appveyor.com/project/rocky/python-filecache/branch/master
-.. |Latest Version| image:: https://pypip.in/version/pyficache/badge.svg?text=version
+.. |Latest Version| image:: https://img.shields.io/pypi/v/pyficache.svg?label=version
    :target: https://pypi.python.org/pypi/pyficache/
-.. |Supported Python versions| image:: https://pypip.in/py_versions/pyficache/badge.svg
+.. |Supported Python versions| image:: https://img.shields.io/pypi/pyversions/pyficache.svg
    :target: https://pypi.python.org/pypi/pyficache/
 .. |Supported Python Versions| image:: https://img.shields.io/pypi/pyversions/pyficache.svg
    :target: https://pypi.python.org/pypi/pyficache/


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20pyficache))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `pyficache`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.